### PR TITLE
fix: return types and laravel helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Documentation
 
-You can find installation instructions and detailed instructions on how to use this package at the [dedicated documentation site](https://docs.ark.io/sdk/frameworks/laravel.html).
+You can find installation instructions and detailed instructions on how to use this package at the [dedicated documentation site](https://sdk.ark.dev/frameworks/laravel).
 
 ## Security
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": "^7.4",
         "arkecosystem/client": "^1.0",
         "graham-campbell/manager": "^4.0",
-        "illuminate/support": "^6.0 | ^7.0 | ^8.0"
+        "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "graham-campbell/testbench": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "require": {
         "php": "^7.4",
         "arkecosystem/client": "^1.0",
-        "graham-campbell/manager": "^4.0"
+        "graham-campbell/manager": "^4.0",
+        "illuminate/support": "^6.0 | ^7.0 | ^8.0"
     },
     "require-dev": {
         "graham-campbell/testbench": "^5.0",

--- a/src/ArkFactory.php
+++ b/src/ArkFactory.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace ArkEcosystem\Ark;
 
 use ArkEcosystem\Client\Connection;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
 /**
@@ -56,7 +57,7 @@ class ArkFactory
             }
         }
 
-        return array_only($config, ['host', 'api_version']);
+        return Arr::only($config, ['host', 'api_version']);
     }
 
     /**

--- a/src/ArkFactory.php
+++ b/src/ArkFactory.php
@@ -28,9 +28,9 @@ class ArkFactory
      *
      * @param array $config
      *
-     * @return \ArkEcosystem\Ark\Client
+     * @return \ArkEcosystem\Client\Connection
      */
-    public function make(array $config): Client
+    public function make(array $config): Connection
     {
         $config = $this->getConfig($config);
 

--- a/src/ArkManager.php
+++ b/src/ArkManager.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace ArkEcosystem\Ark;
 
+use ArkEcosystem\Client\Connection;
 use GrahamCampbell\Manager\AbstractManager;
 use Illuminate\Contracts\Config\Repository;
 
@@ -58,9 +59,9 @@ class ArkManager extends AbstractManager
      *
      * @param array $config
      *
-     * @return \ArkEcosystem\Ark\Client
+     * @return \ArkEcosystem\Client\Connection
      */
-    protected function createConnection(array $config): Client
+    protected function createConnection(array $config): Connection
     {
         return $this->factory->make($config);
     }


### PR DESCRIPTION
## Summary

- Changed `array_only` to [`Arr::only`](https://laravel.com/docs/8.x/helpers), since the [helper package](https://packagist.org/packages/laravel/helpers) is not necessarily installed
- Fixed return types
- Updated link to documentation

### Why are these changes necessary?

I couldn't use the package, the return types are part of PHP and therefore a hard error and not possible try/catch. 

### How were these changes implemented?

See changed files, it's not much :)

## Checklist

- [x] Documentation _(if necessary)_
- [x] Tests _(if necessary)_ -> there are no tests?
- [x] Ready to be merged

```
➜ ./vendor/bin/phpunit
PHPUnit 9.3.10 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.10
Configuration: /.../laravel-1/phpunit.xml.dist
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

No tests executed!
```